### PR TITLE
Add brackets around The Turing Way Community

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -147,7 +147,7 @@ DOI = {10.3390/rs12183062}
 }
 
 @article{Community2019,
-   author = {The Turing Way Community and Becky Arnold and Louise Bowler and Sarah Gibson and Patricia Herterich and Rosie Higman and Anna Krystalli and Alexander Morley and Martin O'Reilly and Kirstie Whitaker},
+   author = {{The Turing Way Community} and Becky Arnold and Louise Bowler and Sarah Gibson and Patricia Herterich and Rosie Higman and Anna Krystalli and Alexander Morley and Martin O'Reilly and Kirstie Whitaker},
    doi = {10.5281/ZENODO.3233986},
    month = {3},
    title = {{The Turing Way}: A Handbook for Reproducible Data Science},


### PR DESCRIPTION
This will prevent the weird abbreviation that's getting generated in the bibliography