### PR TITLE
Fix: correct variable names in CRS comparison within `extract` function

### DIFF
--- a/scikeo/process.py
+++ b/scikeo/process.py
@@ -135,8 +135,8 @@ def extract(image, vector):
     if not isinstance(vector, (gpd.geodataframe.GeoDataFrame)):
         raise TypeError('"vector" must be a vector, tipically a Shapefile (.shp)')
 
-    if not img.crs == endm.crs:
-        raise TypeError(f'Coordinate systems of both the "image" ({img.crs}) and the "vector" ({endm.crs}) must be the same.')
+    if not image.crs == vector.crs:
+        raise TypeError(f'Coordinate systems of both the "image" ({image.crs}) and the "vector" ({vector.crs}) must be the same.')
 
     if not vector.geom_type[0] == 'Point':
         raise TypeError('"Vector" file must have a Point geometry.')


### PR DESCRIPTION
### Description

This PR addresses an issue encountered while extracting the _endmembers_ in the first example notebook, `01.Machine_Learning.ipynb`, for LULC classification using Sentinel-1 and 2 data. In the `extract` function, the CRS comparison was using incorrect variable names (`img` instead of `image` and `endm` instead of `vector`). This caused a `NameError` during execution.
```
import rasterio
import numpy as np
from scikeo.mla import MLA
from scikeo.plot import plotRGB
from scikeo.process import extract
from scikeo.writeRaster import writeRaster
import geopandas as gpd
import matplotlib.pyplot as plt
# from dbfread import DBF
import matplotlib as mpl
import pandas as pd
import sys
import numpy
numpy.set_printoptions(threshold=sys.maxsize)
pd.set_option('display.max_columns', None)
gpd.options.io_engine = "pyogrio"
```
```
# S1S2 GeoTiff file
path_raster = r"D:\work\gee\s1s2_magdalena\drive-download-20240711T205222Z-001\S1S2_Magdalena_2020.tif"
img = rasterio.open(path_raster)

# MultiPoint shapefile
path_endm = r"D:\work\gee\s1s2_magdalena\shp_mag\Samples_LC_Magdalena_2020_pts_noBuffer_Shapefile.shp"
endm = gpd.read_file(path_endm)
endm
```
```
class	geometry
0	0	POINT (-73.89623 10.78071)
1	0	POINT (-73.82291 10.68509)
2	0	POINT (-73.89418 10.71143)
3	0	POINT (-73.96506 10.77223)
4	0	POINT (-74.05143 10.70803)
...	...	...
177	5	POINT (-74.06035 10.18885)
178	5	POINT (-73.96344 10.14826)
179	5	POINT (-73.95292 10.15001)
180	5	POINT (-73.96191 10.15633)
181	5	POINT (-73.96796 10.14113)
```
```
img.crs
```
```
CRS.from_epsg(4326)
```
```
endm.crs
```
```
<Geographic 2D CRS: EPSG:4326>
Name: WGS 84
Axis Info [ellipsoidal]:
- Lat[north]: Geodetic latitude (degree)
- Lon[east]: Geodetic longitude (degree)
Area of Use:
- name: World.
- bounds: (-180.0, -90.0, 180.0, 90.0)
Datum: World Geodetic System 1984 ensemble
- Ellipsoid: WGS 84
- Prime Meridian: Greenwich
```
**Before fix**
```
endm = extract(img, endm)
```
```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
Cell In[8], line 1
----> 1 endm = extract(img, endm)

File [~\senthil\GeoDS\geo_ai\Lib\site-packages\scikeo\process.py:138](http://localhost:8888/lab/tree/~/senthil/GeoDS/geo_ai/Lib/site-packages/scikeo/process.py#line=137), in extract(image, vector)
    135 if not isinstance(vector, (gpd.geodataframe.GeoDataFrame)):
    136     raise TypeError('"vector" must be a vector, tipically a Shapefile (.shp)')
--> 138 if not img.crs == endm.crs:
    139     raise TypeError(f'Coordinate systems of both the "image" ({img.crs}) and the "vector" ({endm.crs}) must be the same.')
    141 if not vector.geom_type[0] == 'Point':

NameError: name 'img' is not defined
```

### Changes Made

- Replaced `img` with `image` and `endm` with `vector` in the CRS comparison within the `extract` function.
- Ensured that the CRS of both the image and vector data are compared correctly before proceeding with data extraction.

### Test

After making the changes, the `extract` function works correctly without errors:

```
endm = extract(img, endm)
endm
```
```
class	band1	band2	band3	band4	band5	band6	band7	band8	band9	band10	band11	band12	band13	band14	band15	band16	band17	band18	band19	band20	band21	band22
0	0	-10.901683	-3.458642	107.0	138.0	279.0	185.000000	571.0	1761.000000	2187.00	2097.000000	2323.0	2464.000000	1036.000000	442.000000	0.837862	-0.338653	-0.575665	-0.293403	-0.765152	2.199724	2367.0	21.131903
1	0	-11.749928	-3.930900	197.0	216.0	409.0	255.000000	690.0	2174.000000	2643.00	2892.000000	2980.0	3099.000000	1366.000000	600.000000	0.837941	-0.358384	-0.539155	-0.314443	-0.752196	2.351944	2386.0	37.600204
2	0	-14.836649	-8.041715	123.5	174.5	341.5	237.000000	625.5	1609.500000	1986.50	2056.500000	2224.5	2429.000000	1034.500000	496.000000	0.793329	-0.330637	-0.503634	-0.273947	-0.715179	2.095474	2481.0	25.496174
3	0	-15.008575	-8.468047	292.5	284.5	443.5	331.500000	700.5	1408.500000	1781.50	1922.000000	1982.5	2537.000000	1171.500000	647.000000	0.705791	-0.242605	-0.450774	-0.189648	-0.625026	2.236047	1936.0	4.680424
4	0	-14.413186	-8.616359	219.5	234.5	485.0	251.500000	853.0	2793.000000	3431.00	3495.000000	3865.0	3847.000000	1701.250000	729.777771	0.865741	-0.345201	-0.556318	-0.312684	-0.756281	2.497882	480.0	13.046054
...	...	...	...	...	...	...	...	...	...	...	...	...	...	...	...	...	...	...	...	...	...	...	...
177	5	-14.940490	-8.145822	962.5	1314.5	1720.5	1980.333374	2361.5	3055.166748	3402.25	3375.949951	3681.0	3528.166748	3624.916748	3019.000000	0.260557	0.035562	-0.356271	0.088853	-0.324824	0.646095	110.0	1.854334
178	5	-13.513328	-6.444684	1215.0	1483.0	1714.0	1925.000000	2211.0	2522.000000	2704.00	2657.000000	2946.0	2904.000000	3443.000000	3180.000000	0.159756	0.128852	-0.335272	0.129154	-0.215740	0.593097	135.0	0.942147
179	5	-13.624151	-7.676836	1144.0	1532.5	1806.5	2033.000000	2258.0	2292.500000	2405.50	2346.000000	2539.0	2692.000000	2969.500000	2852.500000	0.071478	0.117298	-0.243509	0.126562	-0.129922	0.256452	149.0	0.942153
180	5	-14.389661	-5.309675	1099.0	1655.0	1931.5	2097.000000	2308.0	2643.500000	2828.00	2812.000000	3035.0	3145.500000	3397.000000	2991.000000	0.145651	0.094218	-0.275030	0.103102	-0.185622	0.599329	149.0	2.099446
181	5	-14.141673	-7.333766	1035.0	1250.5	1509.0	1566.500000	1871.0	2468.000000	2728.50	2742.500000	3016.5	3082.000000	3141.500000	2737.000000	0.272917	0.067811	-0.351038	0.082174	-0.290133	1.063772	130.0	1.321886
```

### Appreciation
This package is awesome, and I really appreciate the work that has gone into it. Thanks for providing such a useful tool!